### PR TITLE
remove unneccessary console.log statement

### DIFF
--- a/moment-feiertage.js
+++ b/moment-feiertage.js
@@ -17,7 +17,6 @@
 
 
     moment.fn.isHoliday = function(state) {
-    	console.log(state);
     	var year = this.year();
     	// fist get easter date
     	var easter = moment(calculateEasterDate(year)).format();


### PR DESCRIPTION
If the method isHoliday is called with a state parameter, the state is logged to the console.